### PR TITLE
inline randval()

### DIFF
--- a/src/oidentd_util.c
+++ b/src/oidentd_util.c
@@ -68,19 +68,6 @@ int random_seed(void) {
 }
 
 /*
-** Return a pseudo-random integer between 0 and i-1 inclusive. The
-** obvious solution (rand()%i) isn't safe because on many systems,
-** the low-order bits of the return of rand()(3) are grossly non-random.
-** (FIXME: See comment preceding random_seed() regarding using better
-** PRNG functions on systems whose libraries provide them.)
-*/
-
-inline int randval(int i) {
-	/* Per _Numerical Recipes in C_: */
-	return ((double) i * rand() / (RAND_MAX+1.0));
-}
-
-/*
 ** Find the user specified by "temp_user"
 ** Returns 0 on success, -1 on failure.
 */

--- a/src/oidentd_util.h
+++ b/src/oidentd_util.h
@@ -19,6 +19,8 @@
 #ifndef __OIDENTD_UTIL_H
 #define __OIDENTD_UTIL_H
 
+#include <stdlib.h> /* inline randval() */
+
 #define FACILITY	LOG_DAEMON
 #define NORMAL		LOG_INFO
 #define DEBUG		LOG_DEBUG

--- a/src/oidentd_util.h
+++ b/src/oidentd_util.h
@@ -58,7 +58,19 @@ int find_user(const char *temp_user, uid_t *uid);
 int find_group(const char *temp_group, gid_t *gid);
 
 int random_seed(void);
-inline int randval(int i);
+
+/*
+** Return a pseudo-random integer between 0 and i-1 inclusive. The
+** obvious solution (rand()%i) isn't safe because on many systems,
+** the low-order bits of the return of rand()(3) are grossly non-random.
+** (FIXME: See comment preceding random_seed() regarding using better
+** PRNG functions on systems whose libraries provide them.)
+*/
+
+inline int randval(int i) {
+	/* Per _Numerical Recipes in C_: */
+	return ((double) i * rand() / (RAND_MAX+1.0));
+}
 
 #ifndef HAVE_SNPRINTF
 	int snprintf(char *str, size_t n, char const *fmt, ...);


### PR DESCRIPTION
Fix gcc link error due to inline function being defined in .c instead of header. (If you prefer including stdlib.h in everything that includes oident_util.h, I could make the necessary changes.)